### PR TITLE
Change node version from 12.16.2 to 12.16.x

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,13 +1,13 @@
 {
-  "name": "Bremertown",
+  "name": "bremertown chatroom",
   "description": "Another chat.",
   "keywords": [
-    "Bremertown",
-    "Bremerton",
+    "bremertown",
+    "bremerton",
     "chat",
     "chatroom"
   ],
-  "website": "https://github.com/nothingworksright/bremertown_chatroom/blob/master/README.md",
+  "website": "https://www.bremertown.com",
   "repository": "https://github.com/nothingworksright/bremertown_chatroom",
   "success_url": "/"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "readme": "README.md",
   "engines": {
-    "node": "12.16.2"
+    "node": "12.16.x"
   },
   "dependencies": {
     "express": "4.17.1",


### PR DESCRIPTION
Heroku build fails, because it thinks there is no such thing as node version 12.16.2, even though there obviously is. To try and get around that, I'm allowing a range using 12.16.x instead of being specific.